### PR TITLE
Refactor/get slug util

### DIFF
--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -4,17 +4,17 @@ import rehypeAutoLinkHeadings from "rehype-autolink-headings";
 import rehypeCodeTitles from "rehype-code-titles";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
-import { getSlugWithoutCategoryPath } from "./lib/mdx";
+import { getSlugFromPath } from "./lib/posts";
 
 /** @type {import('contentlayer/source-files').ComputedFields} */
 const computedFields = {
   slug: {
     type: "string",
-    resolve: (doc) => getSlugWithoutCategoryPath(doc),
+    resolve: (doc) => getSlugFromPath(doc._raw.flattenedPath),
   },
   url_path: {
     type: "string",
-    resolve: (doc) => `/posts/${getSlugWithoutCategoryPath(doc)}`,
+    resolve: (doc) => `/posts/${getSlugFromPath(doc._raw.flattenedPath)}`,
   },
 
   structuredData: {
@@ -29,7 +29,7 @@ const computedFields = {
         "@type": "Person",
         name: "Minseok Oh",
       };
-      const slug = getSlugWithoutCategoryPath(doc);
+      const slug = getSlugFromPath(doc._raw.flattenedPath);
 
       return {
         "@context": "https://schema.org",

--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -1,6 +1,0 @@
-import { LocalDocument } from "contentlayer/source-files";
-
-export const getSlugWithoutCategoryPath = (doc: LocalDocument): string => {
-  // FIXME: posts/[slug].mdx will cause an error.
-  return doc._raw.flattenedPath.split("/")[1];
-};

--- a/lib/posts/__test__/index.spec.ts
+++ b/lib/posts/__test__/index.spec.ts
@@ -1,6 +1,6 @@
 import { CATEGORY_ALL } from "@/constants/category";
 import { Post } from "contentlayer/generated";
-import { Order, SortBy, getPosts, sortPosts } from "..";
+import { Order, SortBy, getPosts, getSlugFromPath, sortPosts } from "..";
 import { mockPosts } from "./mock";
 
 describe("sortPosts function", () => {
@@ -40,4 +40,23 @@ describe("getPosts function", () => {
       expect(returedValues).toEqual(answer);
     });
   }
+});
+
+describe("getSlugFromPath", () => {
+  const SLUG = "csr-ssr-ssg";
+
+  it("should return slug even category has provided", () => {
+    const path = `web/${SLUG}`;
+    expect(getSlugFromPath(path)).toBe(SLUG);
+  });
+
+  it("should return slug when categories are nested", () => {
+    const path = `web/rendering/${SLUG}`;
+    expect(getSlugFromPath(path)).toBe(SLUG);
+  });
+
+  it("should return slug when category has not provided", () => {
+    const path = SLUG;
+    expect(getSlugFromPath(path)).toBe(SLUG);
+  });
 });

--- a/lib/posts/index.ts
+++ b/lib/posts/index.ts
@@ -1,5 +1,5 @@
-import { CATEGORY_ALL } from "@/constants/category";
 import { Post, allPosts } from "contentlayer/generated";
+import { CATEGORY_ALL } from "../../constants/category";
 
 type CategoryWithCount = {
   [key: string]: number;
@@ -103,3 +103,11 @@ export function getPostsByCategory(category: string) {
 
   return posts;
 }
+
+export const getSlugFromPath = (path: string): string => {
+  const startIndexOfLastSegment = path.lastIndexOf("/");
+
+  return startIndexOfLastSegment !== -1
+    ? path.slice(startIndexOfLastSegment + 1)
+    : path;
+};


### PR DESCRIPTION
## util 함수 리팩토링
- /category/slug 만 대응할 수 있던 기존 util 함수를 /slug, /category/category/slug 와 같이 slug가 있다면 항상 대응할 수 있도록 리팩토링