### PR TITLE
refactor: getCategories only in server component

### DIFF
--- a/components/layout/category-nav/category-chip.tsx
+++ b/components/layout/category-nav/category-chip.tsx
@@ -1,20 +1,19 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { CATEGORY_ALL, CATEGORY_NAME_LABELS } from "@/constants/category";
 import Chip from "./chip";
 
 type Props = {
   name: string;
   count: number;
-  currentCategoryName: string;
 };
 
-export default function CategoryChip({
-  name,
-  count,
-  currentCategoryName,
-}: Props) {
+export default function CategoryChip({ name, count }: Props) {
+  const pathname = usePathname();
+  const currentCategoryName = getCategoryNameFromPath(pathname);
+
   const urlPath = getPath(name);
   const label = getLabel(name, count);
   const isSelected = name === currentCategoryName;
@@ -24,6 +23,13 @@ export default function CategoryChip({
       <Chip label={label} isSelected={isSelected} />
     </Link>
   );
+}
+
+function getCategoryNameFromPath(pathname: string) {
+  const regex = /pages|\/|category|\d+/g;
+  const category = pathname.replace(regex, "");
+
+  return category === "" ? CATEGORY_ALL : category;
 }
 
 function getPath(name: string) {

--- a/components/layout/category-nav/index.tsx
+++ b/components/layout/category-nav/index.tsx
@@ -1,13 +1,8 @@
-"use client";
-
-import { usePathname } from "next/navigation";
 import { CATEGORY_ALL } from "@/constants/category";
 import { getAllCategoriesWithCount } from "@/lib/posts";
 import CategoryChip from "@/components/layout/category-nav/category-chip";
 
 export default function CategoryNav() {
-  const pathname = usePathname();
-  const currentCategoryName = getCategoryNameFromPath(pathname);
   const categories = getAllCategoriesWithCount();
 
   return (
@@ -15,18 +10,10 @@ export default function CategoryNav() {
       {categories?.map((category) => (
         <CategoryChip
           key={category.name}
-          currentCategoryName={currentCategoryName}
           name={category.name}
           count={category.count}
         />
       ))}
     </div>
   );
-}
-
-function getCategoryNameFromPath(pathname: string) {
-  const regex = /pages|\/|category|\d+/g;
-  const category = pathname.replace(regex, "");
-
-  return category === "" ? CATEGORY_ALL : category;
 }


### PR DESCRIPTION
## Key changes 💡
- Client component에서 util을 사용하기 위해 전체 글 json이 브라우저로 전달되고 있었고, 이는 낭비
- getCategory util을 Server component로 위임하여 브라우저에 필요한 데이터만 보내도록 수정
